### PR TITLE
Fix dependency typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ project = pipenvlib.PipenvProject('.')
 
 ```pycon
 >>> project.packages
-[<Depedency 'toml' constraint='*'>, <Depedency 'delegator.py' constraint='*'>]
+[<Dependency 'toml' constraint='*'>, <Dependency 'delegator.py' constraint='*'>]
 
 >>> project.locked_packages
-[<LockedDepedency 'delegator.py==0.0.14'>, <LockedDepedency 'pexpect==4.3.1'>, <LockedDepedency 'ptyprocess==0.5.2'>, <LockedDepedency 'toml==0.9.4'>]
+[<LockedDependency 'delegator.py==0.0.14'>, <LockedDependency 'pexpect==4.3.1'>, <LockedDependency 'ptyprocess==0.5.2'>, <LockedDependency 'toml==0.9.4'>]
 
 >>> project.install('requests', dev=True)
 True
 
 >>> project.dev_packages
-[<Depedency 'requests' constraint='*'>]
+[<Dependency 'requests' constraint='*'>]
 ```
 
 >>> project.virtualenv_location

--- a/pipenvlib.py
+++ b/pipenvlib.py
@@ -14,7 +14,7 @@ class Dependency(object):
         self.locked = locked
 
     def __repr__(self):
-        return "<Depedency '{0}' constraint='{1}'>".format(
+        return "<Dependency '{0}' constraint='{1}'>".format(
             self.name, self.constraint
         )
 
@@ -28,7 +28,7 @@ class LockedDependency(object):
         self.hashes = hashes
 
     def __repr__(self):
-        return "<LockedDepedency '{0}{1}'>".format(
+        return "<LockedDependency '{0}{1}'>".format(
             self.name, self.constraint
         )
 


### PR DESCRIPTION
"Depedency" for "Dependency" popped up in a lot of places, but based on the class names it doesn't look like it was intentional.